### PR TITLE
yeetpls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ luac.out
 *.i*86
 *.x86_64
 *.hex
+
+## mpv stuff ##
+script-opts/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .komodotools
 
 ##Lua##
+test.lua
 # Compiled Lua sources #
 luac.out
 # luarocks build files #

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is just a dumpsite for me for any mpv scripts I create. I decide
 Then after pondering how to do this, I figured I might as well write some scripts for [mpv](https://mpv.io) since I use the player a lot and there's some functionality I can think of that I'd like to have.
 
 ## Scripts to be found here ##
-If the script doesn't exist yet, expect a branch to be made soon™. If you have suggestions, feel free to fork or contact me\* about it!
+If the script doesn't exist yet, expect a branch to be made soon™. If you have suggestions, feel free to fork or contact me[\*](#Contact) about it!
 |    Name    |                Description                |
 |------------|-------------------------------------------|
 | yeet-pls   | Delete playlist entries after playing them, or the entire playlist file when done |
@@ -19,7 +19,7 @@ Branches in this repo will be ordered a bit different from most projects because
 - Changes to a script should **only** be made in the branch of the same name;
 - If a branch doesn't exist, create it;
 - If a script is deemed stable and complete, the branch will be deleted after 9 weeks of inactivity;
-- If you wish to contribute to this repo rather than fork, shoot me a message\* and we'll see if I can add you;
+- If you wish to contribute to this repo rather than fork, shoot me a message[\*](#Contact) and we'll see if I can add you;
   - It's advisable to have sent in PRs before you request being added to the repo.
 
 # Contact #

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is just a dumpsite for me for any mpv scripts I create. I decide
 Then after pondering how to do this, I figured I might as well write some scripts for [mpv](https://mpv.io) since I use the player a lot and there's some functionality I can think of that I'd like to have.
 
 ## Scripts to be found here ##
-If the script doesn't exist yet, expect a branch to be made soon™. If you have suggestions, feel free to fork or contact me[\*](#Contact) about it!
+If the script doesn't exist yet, expect a branch to be made soon™. If you have suggestions, feel free to fork or [contact me](#Contact) about it!
 |    Name    |                Description                |
 |------------|-------------------------------------------|
 | yeet-pls   | Delete playlist entries after playing them, or the entire playlist file when done |
@@ -19,8 +19,13 @@ Branches in this repo will be ordered a bit different from most projects because
 - Changes to a script should **only** be made in the branch of the same name;
 - If a branch doesn't exist, create it;
 - If a script is deemed stable and complete, the branch will be deleted after 9 weeks of inactivity;
-- If you wish to contribute to this repo rather than fork, shoot me a message[\*](#Contact) and we'll see if I can add you;
-  - It's advisable to have sent in PRs before you request being added to the repo.
+- If you wish to contribute to this repo rather than fork, [shoot me a message](#Through-Discord) and we'll see if I can add you;
+  - It's advisable to have sent in PRs before you request being added to the repo as a contributor.
+  - In some cases of ~~favoritism~~ personal contacts, I'll add people I know and have faith in to write good code
 
 # Contact #
-You can reach me through the issue system here on github, or through Discord as `@Scuffed Riven#0042`.
+## Through GitHub ##
+Feel free to fork the repo and send in a PR, or use the Issue system to notify me of bugs and missing features.
+
+## Through Discord ##
+You can find me in various servers, or shoot me a DM. You should be able to find me pretty easily, my tag is `@Scuffed Riven#0042`.

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -7,7 +7,7 @@ If this doesn't work, it notifies the user with an `error` message and exits.
 This script does not care about where it's being run from. So long as mpv can resolve the file names from the playlist, it's assumed this script can as well with no extra info
 
 ## Parsers ##
-A new parser for a type of playlist files should provide at least one function:
+A new parser for a type of playlist files should provide at least two functions:
 - `format_pls`:
 	- Arguments given to a parser are always the same, in the given order:
 		- The playlist as read from the file, as a string.
@@ -18,6 +18,17 @@ A new parser for a type of playlist files should provide at least one function:
 			- Inner table: `pair`s of Stream Type (string) and the actual URL.
 	- The value returned should be a string that can be written to a playlist file, according to the playlist spec.
 	- **Make sure to add it to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
+- `test_format`:
+	- Argument given for this function is always just the content of the file.
+	- The value returned should be a boolean
+	- If multiple format specs allow for the same parser to be used (m3u/m3u8 for example), an extra step is required:
+		- Mention this in any PR to add functionality
+		- Provide a list of all formats that match
+	- Provide an internal way of matching the spec
+	- Do not throw errors if a file is a mismatch to the spec
+		- Either use `print` or `mp.msg.warn` to notify the user of this.
+		- Optionally print a single line message on the OSD
+		- `return false` makes main.lua attempt to use a fallback, if that fails it provides a clean exit.
 
 Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
 So long as it translates between mpv's internal playlist objects and the type of playlist it processes, this code is gonna be happy with it.

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -16,8 +16,6 @@ A new parser for a type of playlist files should provide at least one function:
 			- In Lua, this becomes an indexed table of tables:
 			- Top level: `ipair`s of a number and a table to determine the order;
 			- Inner table: `pair`s of Stream Type (string) and the actual URL.
-		- The total amount of entries in the playlist.
-		- The current position in the playlist
 	- The value returned should be a string that can be written to a playlist file, according to the playlist spec.
 	- **Make sure to add it to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
 

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -1,0 +1,20 @@
+# yeetpls #
+A fairly simple script that leverages more complex parsers to delete entries from playlist files after they have finished playing.
+The main script only determines the type of playlist given and tries to call `<filetype>-parser.lua` to handle the parsing code.
+If it can't find an applicable parser, it will try to parse any playlist type **the way mpv processes plaintext playlists**. Notably: every line should be just an entry you can play by itself when using `mpv <entry>`.
+If this doesn't work, it notifies the user with an `error` message and exits.
+
+This script does not care about where it's being run from. So long as mpv can resolve the file names from the playlist, it's assumed this script can as well with no extra info
+
+## Parsers ##
+A new parser for a type of playlist files should provide a couple of functions with standardized names:
+- `read_to_playlist`: Should take in a string (the full contents of the playlist file) and return a list of just the file entries. These should be kept as they are.
+	- If supplied files are just filenames, return just filenames;
+	- If supplied files are a full path, return full paths.
+	- If supplied files are Windows paths, return Windows paths
+	- And if they're relative, return them relative.
+- `format_playlist`: Should take in a list of items and transform it to a playlist of the type it parses. It should return this as one long string
+	- Stick to whatever the spec for the playlist type is
+	- Ensure it's valid enough that it can be passed to mpv's `--playlist` switch and just play everything
+Whatever else these parsers do internally is irrelevant. Make them perform black magic for all I care,
+so long as it translates between mpv's internal playlist objects and the type of playlist it processes.

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -25,6 +25,10 @@ A new parser for a type of playlist files should provide at least two functions:
 		- Mention this in any PR to add functionality
 		- Provide a list of all formats that match
 	- Provide an internal way of matching the spec
+	- Try to also match the current file content
+		- Examples include not adding optional fields that the file currently doesn't use
+		- Not dropping fields that could fairly easily be implemented
+		- If a file takes note of URL/local file/webstream, please try to match this in the output
 	- Do not throw errors if a file is a mismatch to the spec
 		- Either use `print` or `mp.msg.warn` to notify the user of this.
 		- Optionally print a single line message on the OSD

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -7,14 +7,28 @@ If this doesn't work, it notifies the user with an `error` message and exits.
 This script does not care about where it's being run from. So long as mpv can resolve the file names from the playlist, it's assumed this script can as well with no extra info
 
 ## Parsers ##
-A new parser for a type of playlist files should provide a couple of functions with standardized names:
-- `read_to_playlist`: Should take in a string (the full contents of the playlist file) and return a list of just the file entries. These should be kept as they are.
-	- If supplied files are just filenames, return just filenames;
-	- If supplied files are a full path, return full paths.
-	- If supplied files are Windows paths, return Windows paths
-	- And if they're relative, return them relative.
-- `format_playlist`: Should take in a list of items and transform it to a playlist of the type it parses. It should return this as one long string
-	- Stick to whatever the spec for the playlist type is
-	- Ensure it's valid enough that it can be passed to mpv's `--playlist` switch and just play everything
-Whatever else these parsers do internally is irrelevant. Make them perform black magic for all I care,
-so long as it translates between mpv's internal playlist objects and the type of playlist it processes.
+A new parser for a type of playlist files should provide at least one function:
+- `format_pls`:
+	- Arguments given to a parser are always the same, in the given order:
+		- The playlist as read from the file, as a string.
+			- This is the _original file_ and entries have **not yet been removed**.
+		- The `playlist` object as returned by mpv's `mp.get_property_native("playlist")`.
+			- In Lua, this becomes an indexed table of tables:
+			- Top level: `ipair`s of a number and a table to determine the order;
+			- Inner table: `pair`s of Stream Type (string) and the actual URL.
+		- The total amount of entries in the playlist.
+		- The current position in the playlist
+	- The value returned should be a string that can be written to a playlist file, according to the playlist spec.
+	- **Make sure to add it to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
+Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
+So long as it translates between mpv's internal playlist objects and the type of playlist it processes, this code is gonna be happy with it.
+
+## Notes ##
+This script assumes that **there is no shuffle applied**. It was made with the intention of automating the entire process from acquiring anime down to watching the show without doing anything
+other than pointing mpv to a playlist. I personally set up a simple script to run on download completion that automatically generates a file `playlist.txt` which is just a list of file names
+in the directory that don't match certain patterns.
+
+If you apply shuffle, make sure that the playlist format you use gets processed by a parser that actually filters the entries by comparison. The `txt` parser is guaranteed to provide
+this functionality, because the file format is extremely easy to use and the largest workload is extracting all remaining file names.
+
+~~the `txt` parser is also the only one guaranteed to actually exist. I'm lazy and if it works for _me_, I'm usually happy~~

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -11,6 +11,11 @@ You must both pass the playlist file to mpv however you normally would and, due 
 Optionally also pass the script-opt `create_file=true` if it doesn't exist and you want it to be made. _If it doesn't exist and you don't pass this option, it **will** error and exit._
 Current behavior is to bypass read check on the file and immediately open it in `a+` for reading, appending and creating.
 
+For parsers that provide playlist loading functionality as well (or those that leverage existing parsers' code to do so), you may also run mpv with
+`mpv --idle=once --script-opts=yeetpls-playlist=path/to/playlist` together with any other options and flags you'd usually set. This makes the script double as a playlist loader for mpv,
+so that it bypasses use of the `--playlist` flag altogether. _This functionality was born out of necessity and might not function as expected. This is also a cheap workaround to fix what I believe
+is a genuinely lacking feature on mpv's end_.
+
 This script assumes that **there is no shuffle applied**. It was made with the intention of automating the entire process from acquiring anime down to watching the show without doing anything
 other than pointing mpv to a playlist. I personally set up a simple script to run on download completion that automatically generates a file `playlist.txt` which is just a list of file names
 in the directory that don't match certain patterns. If you apply shuffle, make sure that the playlist format you use gets processed by a parser that actually filters the entries by comparison.
@@ -45,10 +50,13 @@ A new parser for a type of playlist files should provide at least two functions:
 	- The value returned should be a string that can be written to a playlist file, according to the playlist spec.
 - `test_format`:
 	- Argument given for this function is always just the content of the file.
-	- The value returned should be a boolean
+	- The value returned should be a boolean.
 	- If multiple format specs allow for the same parser to be used (m3u/m3u8 for example), an extra step is required:
 		- Mention this in any PR to add functionality
 		- Provide a list of all formats that match
+		- Explain _why_ this shouldn't be a separate parser. Following m3u8 example: does mpv handle the charset internally?
+		- This will probably end up with a translation table of `format, parser` where there will be duplicate entries in the parser field
+			- Feel free to suggest a better fix :^)
 	- Provide an internal way of matching the spec
 	- Try to also match the current file content
 		- Examples include not adding optional fields that the file currently doesn't use
@@ -58,6 +66,11 @@ A new parser for a type of playlist files should provide at least two functions:
 		- Either use `print` or `mp.msg.warn` to notify the user of this.
 		- Optionally print a single line message on the OSD
 		- `return false` makes main.lua attempt to use a fallback, if that fails it provides a clean exit.
+- Optionally provide a `load_pls` function that takes the content of the playlist file as an argument
+	- This works to make the parser an alternative playlist loader to bypass `--playlist` altogether
+	- Make sure the parser object returned contains a field `loader` set to `true`
+	- Return value should be a table with just the file names or paths to load into mpv's internal playlist object
+	- `main.lua` will handle the actual updating of the internal playlist.
 
 **Make sure to add these to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
 

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -20,6 +20,7 @@ A new parser for a type of playlist files should provide at least one function:
 		- The current position in the playlist
 	- The value returned should be a string that can be written to a playlist file, according to the playlist spec.
 	- **Make sure to add it to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
+
 Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
 So long as it translates between mpv's internal playlist objects and the type of playlist it processes, this code is gonna be happy with it.
 

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -7,14 +7,10 @@ If this doesn't work, it notifies the user with an `error` message and exits.
 This script does not care about where it's being run from. So long as mpv can resolve the file names from the playlist, it's assumed this script can as well with no extra info
 
 ## Usage Notes ##
-You must both pass the playlist file to mpv however you normally would and, due to a [limitation in mpv](#Known-Issues), you must also pass the file to `--script-ops=yeetpls-playlist=<file>`.
+Due to a [limitation in mpv](#Known-Issues), you must pass the playlist file to `--script-ops=yeetpls-playlist=<file>`. Thanks to the `loadlist` internal input command, this script can **replace**
+the need for an input file or the use of the `--playlist` option.
 Optionally also pass the script-opt `create_file=true` if it doesn't exist and you want it to be made. _If it doesn't exist and you don't pass this option, it **will** error and exit._
 Current behavior is to bypass read check on the file and immediately open it in `a+` for reading, appending and creating.
-
-For parsers that provide playlist loading functionality as well (or those that leverage existing parsers' code to do so), you may also run mpv with
-`mpv --idle=once --script-opts=yeetpls-playlist=path/to/playlist` together with any other options and flags you'd usually set. This makes the script double as a playlist loader for mpv,
-so that it bypasses use of the `--playlist` flag altogether. _This functionality was born out of necessity and might not function as expected. This is also a cheap workaround to fix what I believe
-is a genuinely lacking feature on mpv's end_.
 
 This script assumes that **there is no shuffle applied**. It was made with the intention of automating the entire process from acquiring anime down to watching the show without doing anything
 other than pointing mpv to a playlist. I personally set up a simple script to run on download completion that automatically generates a file `playlist.txt` which is just a list of file names
@@ -31,7 +27,7 @@ Currently, due to a limitation of mpv, the script is unable to fetch the playlis
 a playlist file gets provided, the script currently requires a user to set a script-opt instead. The script-opt to be set is `yeetpls-playlist`, as per the standard outlined on mpv.io to
 automatically look for any script-opt named {script_name}-{opt_name}.
 
-Yes, this means specifying the file twice. Don't complain to me about this, I'm just the messenger. I already sent in a [feature request](https://github.com/mpv-player/mpv/issues/8508)
+Yes, this means specifying the file twice, or setting `--idle=[once | yes]`. Don't complain to me about this, I'm just the messenger. I already sent in a [feature request](https://github.com/mpv-player/mpv/issues/8508)
 to fix this, including all information I could get my hands on in regards to getting the playlist files. Someone suggested a possible fix on init time, but it doesn't work with the `--playlist` option.
 Feel free to suggest other ways of attempting to get the file though!
 _Behavior for this problem might change to instead attempt to load the playlist from just the script-opt and having the user add the flag to not close on idling. This remains to be seen as it changes
@@ -66,11 +62,6 @@ A new parser for a type of playlist files should provide at least two functions:
 		- Either use `print` or `mp.msg.warn` to notify the user of this.
 		- Optionally print a single line message on the OSD
 		- `return false` makes main.lua attempt to use a fallback, if that fails it provides a clean exit.
-- Optionally provide a `load_pls` function that takes the content of the playlist file as an argument
-	- This works to make the parser an alternative playlist loader to bypass `--playlist` altogether
-	- Make sure the parser object returned contains a field `loader` set to `true`
-	- Return value should be a table with just the file names or paths to load into mpv's internal playlist object
-	- `main.lua` will handle the actual updating of the internal playlist.
 
 **Make sure to add these to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
 

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -7,23 +7,26 @@ If this doesn't work, it notifies the user with an `error` message and exits.
 This script does not care about where it's being run from. So long as mpv can resolve the file names from the playlist, it's assumed this script can as well with no extra info
 
 ## Usage Notes ##
+You must both pass the playlist file to mpv however you normally would and, due to a [limitation in mpv](#Known-Issues), you must also pass the file to `--script-ops=yeetpls-playlist=<file>`.
+Optionally also pass the script-opt `create_file=true` if it doesn't exist and you want it to be made. _If it doesn't exist and you don't pass this option, it **will** error and exit._
+Current behavior is to bypass read check on the file and immediately open it in `a+` for reading, appending and creating.
+
 This script assumes that **there is no shuffle applied**. It was made with the intention of automating the entire process from acquiring anime down to watching the show without doing anything
 other than pointing mpv to a playlist. I personally set up a simple script to run on download completion that automatically generates a file `playlist.txt` which is just a list of file names
-in the directory that don't match certain patterns.
-
-If you apply shuffle, make sure that the playlist format you use gets processed by a parser that actually filters the entries by comparison. The `txt` parser is guaranteed to provide
-this functionality, because the file format is extremely easy to use and the largest workload is extracting all remaining file names. Creating a playlist for it is as easy as redirecting
-the output of `ls` (or `dir` with the correct flags under Windows) to a text file, or just aggregating all full paths for the media you want in it in a single file.
+in the directory that don't match certain patterns. If you apply shuffle, make sure that the playlist format you use gets processed by a parser that actually filters the entries by comparison.
+The `txt` parser is guaranteed to provide this functionality, because the file format is extremely easy to use and the largest workload is extracting all remaining file names.
+Creating a playlist for it is as easy as redirecting the output of `ls` (or `dir` with the correct flags under Windows) to a text file,
+or just aggregating all full paths for the media you want in it in a single file. One playlist entry per line, as per mpv's plaintext playlist handler.
 
 ~~the `txt` parser is also the only one guaranteed to actually exist. I'm lazy and if it works for _me_, I'm usually happy~~
 
 ## Known issues ##
+### Specifying the playlist twice ###
 Currently, due to a limitation of mpv, the script is unable to fetch the playlist file provided with the `--playlist` command line option. Because it's not good practice to gamble on how
-a playlist file gets provided, the script currently requires a user to set a script-opt instead. The easiest way is to alias something that includes the script-opt if your playlists are generated with
-static file names, or to set it in a config file. The script-opt to be set is `yeetpls-playlist`,
-as per the standard outlined on mpv.io to automatically look for any script-opt named {script_name}-{opt_name}.
+a playlist file gets provided, the script currently requires a user to set a script-opt instead. The script-opt to be set is `yeetpls-playlist`, as per the standard outlined on mpv.io to
+automatically look for any script-opt named {script_name}-{opt_name}.
 
-Yes, this means specifying the file twice. Don't complain to me about this, go to the mpv repository. I already sent in a [feature request](https://github.com/mpv-player/mpv/issues/8508)
+Yes, this means specifying the file twice. Don't complain to me about this, I'm just the messenger. I already sent in a [feature request](https://github.com/mpv-player/mpv/issues/8508)
 to fix this, including all information I could get my hands on in regards to getting the playlist files. Someone suggested a possible fix on init time, but it doesn't work with the `--playlist` option.
 Feel free to suggest other ways of attempting to get the file though!
 _Behavior for this problem might change to instead attempt to load the playlist from just the script-opt and having the user add the flag to not close on idling. This remains to be seen as it changes
@@ -40,7 +43,6 @@ A new parser for a type of playlist files should provide at least two functions:
 			- Top level: `ipair`s of a number and a table to determine the order;
 			- Inner table: `pair`s of Stream Type (string) and the actual URL.
 	- The value returned should be a string that can be written to a playlist file, according to the playlist spec.
-	- **Make sure to add it to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
 - `test_format`:
 	- Argument given for this function is always just the content of the file.
 	- The value returned should be a boolean
@@ -56,7 +58,8 @@ A new parser for a type of playlist files should provide at least two functions:
 		- Either use `print` or `mp.msg.warn` to notify the user of this.
 		- Optionally print a single line message on the OSD
 		- `return false` makes main.lua attempt to use a fallback, if that fails it provides a clean exit.
-	- This requirement might be dropped, as it would require testing for optional fields in several formats.
+
+**Make sure to add these to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
 
 Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
 So long as it translates between mpv's internal playlist objects and the type of playlist it processes, this code is gonna be happy with it.

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -6,6 +6,29 @@ If this doesn't work, it notifies the user with an `error` message and exits.
 
 This script does not care about where it's being run from. So long as mpv can resolve the file names from the playlist, it's assumed this script can as well with no extra info
 
+## Usage Notes ##
+This script assumes that **there is no shuffle applied**. It was made with the intention of automating the entire process from acquiring anime down to watching the show without doing anything
+other than pointing mpv to a playlist. I personally set up a simple script to run on download completion that automatically generates a file `playlist.txt` which is just a list of file names
+in the directory that don't match certain patterns.
+
+If you apply shuffle, make sure that the playlist format you use gets processed by a parser that actually filters the entries by comparison. The `txt` parser is guaranteed to provide
+this functionality, because the file format is extremely easy to use and the largest workload is extracting all remaining file names. Creating a playlist for it is as easy as redirecting
+the output of `ls` (or `dir` with the correct flags under Windows) to a text file, or just aggregating all full paths for the media you want in it in a single file.
+
+~~the `txt` parser is also the only one guaranteed to actually exist. I'm lazy and if it works for _me_, I'm usually happy~~
+
+## Known issues ##
+Currently, due to a limitation of mpv, the script is unable to fetch the playlist file provided with the `--playlist` command line option. Because it's not good practice to gamble on how
+a playlist file gets provided, the script currently requires a user to set a script-opt instead. The easiest way is to alias something that includes the script-opt if your playlists are generated with
+static file names, or to set it in a config file. The script-opt to be set is `yeetpls-playlist`,
+as per the standard outlined on mpv.io to automatically look for any script-opt named {script_name}-{opt_name}.
+
+Yes, this means specifying the file twice. Don't complain to me about this, go to the mpv repository. I already sent in a [feature request](https://github.com/mpv-player/mpv/issues/8508)
+to fix this, including all information I could get my hands on in regards to getting the playlist files. Someone suggested a possible fix on init time, but it doesn't work with the `--playlist` option.
+Feel free to suggest other ways of attempting to get the file though!
+_Behavior for this problem might change to instead attempt to load the playlist from just the script-opt and having the user add the flag to not close on idling. This remains to be seen as it changes
+the requirements to parsers as well, to read playlists on start and parse them to a table instead of just the other way around. Imagine the extra effort this would take_
+
 ## Parsers ##
 A new parser for a type of playlist files should provide at least two functions:
 - `format_pls`:
@@ -33,16 +56,7 @@ A new parser for a type of playlist files should provide at least two functions:
 		- Either use `print` or `mp.msg.warn` to notify the user of this.
 		- Optionally print a single line message on the OSD
 		- `return false` makes main.lua attempt to use a fallback, if that fails it provides a clean exit.
+	- This requirement might be dropped, as it would require testing for optional fields in several formats.
 
 Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
 So long as it translates between mpv's internal playlist objects and the type of playlist it processes, this code is gonna be happy with it.
-
-## Notes ##
-This script assumes that **there is no shuffle applied**. It was made with the intention of automating the entire process from acquiring anime down to watching the show without doing anything
-other than pointing mpv to a playlist. I personally set up a simple script to run on download completion that automatically generates a file `playlist.txt` which is just a list of file names
-in the directory that don't match certain patterns.
-
-If you apply shuffle, make sure that the playlist format you use gets processed by a parser that actually filters the entries by comparison. The `txt` parser is guaranteed to provide
-this functionality, because the file format is extremely easy to use and the largest workload is extracting all remaining file names.
-
-~~the `txt` parser is also the only one guaranteed to actually exist. I'm lazy and if it works for _me_, I'm usually happy~~

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -121,7 +121,7 @@ if options.make_config then
 		file:write("# Playlist file to load. Setting this here can cause some issues, so be careful!\nplaylist=None # [None | any file path or name you want]")
 		file:write("# Whether or not to create the playlist file if it doesn't already exist. Some edge cases can cause issues.\ncreate_file=false\n\n")
 		file:write("# Emergency option to exit the script without doing anything. THIS SHOULD ONLY BE SET TO TRUE THROUGH --SCRIPT-OPS. Disables the script entirely!\nexit=false\n")
-		-- Files should end with a blank line, this is common sense.
+		-- Files should end with a newline, this is common sense.
 	end
 end
 

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -20,7 +20,7 @@ local options = {
 
 	-- The type of playlist, used for processing defaults internally. Default is "auto" and makes the script check it
 	-- This list of filetypes is arbitrary and "auto" will allow for parsing anything that has a parser script available
-	playlist_type = "auto", -- ("txt" | "m3u" | "m3u8" | "pls" | *"auto")
+	playlist_type = "auto", -- ("txt" | *"auto" | the name of any of the existing parsers)
 	-- The playlist file. Due to limitations in the Lua env, this needs to be passed as a script-opt.
 	-- This playlist is parsed internally and only parses playlist types for which a parser is available.
 	playlist = "None", -- ("None" | "[/path/to/]<playlist_file.ext>")
@@ -109,14 +109,14 @@ function pls_remove(event)
 	end
 	-- Any other reason is a go-ahead to remove
 	local plsID = event.playlist_entry_id
+	-- remove it from the comparison table
+	mpv_pls:remove(plsID)
 	-- If the last file finishes playing, reason is still eof
 	-- So check if this was the last entry and if so, delete the playlist file.
 	if #mpv_pls <= 1 then
 		os.remove(options.playlist)
 		pls_deleted = true
 	end
-	-- remove it from the comparison table
-	mpv_pls:remove(plsID)
 end
 mp.register_event("end-file", pls_remove)
 

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -2,10 +2,12 @@
 local opts = require("mp.options")
 local utils = require("mp.utils")
 local msg = require("mp.msg")
+local filetype = nil -- used internally in places for the error state
+local mpv_pls = nil -- populated internally with mpv's playlist, so a list of
 local parser = nil
+local parser_name = nil -- This value is only used when stuff errors
+local pls_old = nil
 local options = {
-	-- The OS type, or an approximation anyway. auto makes the script check it
-	system = "auto",
 	-- whether or not to auto-delete playlist entries after playing them
 	auto_delete_entries = true, -- (*true | false)
 	-- Whether to delete the playlist file if the last file is played
@@ -14,35 +16,67 @@ local options = {
 	info_on_start = true, -- (*true | false)
 	-- Print info like remaining titles and title on the next entry
 	info_on_next = false, -- (true | *false)
+
 	-- The type of playlist, used for processing defaults internally. Default is "auto" and makes the script check it
 	-- This list of filetypes is arbitrary and "auto" will allow for parsing anything that has a parser script available
 	playlist_type = "auto", -- ("txt" | "m3u" | "m3u8" | "pls" | *"auto")
 	-- The playlist file. Due to limitations in the Lua env, this needs to be passed as a script-opt.
 	-- This playlist is parsed internally and only parses playlist types for which a parser is available.
-	playlist = "None" -- ("None" | "[/path/to/]<playlist_file.ext>")
+	playlist = "None", -- ("None" | "[/path/to/]<playlist_file.ext>")
+	-- Whether to create the playlist file if it doesn't exist yet
+	create_file = false -- (true | *false)
 }
 opts.read_options(options, "yeetpls")
 
+-- Basic initialization. Wrapped in a function so we can properly exit the script if anything fails
 function base_init()
-	--check OS type, borrowed from https://github.com/jonniek/mpv-playlistmanager/blob/8f01f38d71bdf02a3b61988a940a5fc0db3b573c/playlistmanager.lua#L171
-	if options.system=="auto" then
-	  local o = {}
-	  if mp.get_property_native('options/vo-mmcss-profile', o) ~= o then
-	    options.system = "windows"
-	  else
-	    options.system = "linux"
-	  end
-	end
-	if options.playlist_type == "auto" then
-		local filetype = options.playlist:reverse():match('.*%p'):reverse():sub(2)
+	if options.playlist_type == "auto" then -- Determine the type of playlist, this is based on the extension
+		filetype = options.playlist:reverse():match('.*%p'):reverse():sub(2)
 		print("Reading playlist of type "..filetype)
-		parser = require(filetype.."-parser")
+		-- More than willing to accept PRs that add tables to map extensions to playlist types,
+		-- in order to allow one parser to be used with any legal file type extension
+	else
+		filetype = options.playlist_type -- It's expected that users know what they're doing when setting this opt
+		-- If you named your file "some.esoteric.format.kekw", but it's just plaintext, you'll wanna set this.
+		-- If it's anything that just lists a file per line like it's `ls`, leave this option alone.
+		-- By default, it tries to parse unknown filetypes as `txt`
 	end
+	-- Not sure what happens if I define a new variable and use an existing one,
+	-- better make sure both exist.
+	local hasparser = nil
+	-- Test if we have a parser for this
+	hasparser,parser = pcall(require, filetype.."-parser")
+	if not hasparser then
+		-- default to the txt-parser
+		parser = require("txt-parser")
+		parser_name = "txt-parser"
+	else
+		-- We have a parser, save the name in case of errors
+		parser_name = filetype.."-parser"
+	end
+	-- Open the file for appending and reading, this tests for both read and write permissions.
+	local pls_file,err,errcode = io.open(options.playlist, "a+")
+	if err then -- We don't have read and/or write, error and exit
+		print("Recieved error code "..errcode..": "..err..".\nCannot process playlist, exiting...")
+		return false
+	else
+		pls_old = pls_file:read("*all") -- Save the old playlist, should be fairly small
+		pls_file:close() -- Close the file properly
+		mpv_pls = mp.get_property_native("playlist") -- Array of objects => indexed table of tables. [{"filename", <file path>}...]
+	end
+	-- Everything was successful, time to actually do stuff here!
+	return true
 end
 
-if not options.playlist == "None" then
-	print("No playlist given in the form of --script-opts=yeetpls-playlist=playlist.ext\n\tExiting extension...")
+if options.playlist == "None" then
+	print("No playlist given to the --script-opts=yeetpls=<playlist file> switch. Exiting extension...")
 	return
 else
-	base_init()
+	if not base_init() then -- something caused a failure, exit.
+		print(parser_name.." was unable to parse this playlist type ("..filetype.."). Exiting...")
+		return
+	else
+		-- TESTING INFO, success!
+		print("loading "..parser_name.." was successful!")
+	end
 end

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -9,37 +9,40 @@ local pls_old = nil -- The old playlist file's content
 local mpv_pls = nil -- populated internally with mpv's playlist
 local script_dir = nil
 local options = {
-	make_config = true,
+	makeConfig = "yes",
 	-- whether or not to auto-delete playlist entries after playing them
-	auto_delete_entries = true, -- (*true | false)
+	autoDeleteEntries = "yes", -- (*yes | no)
 	-- Whether to delete the playlist file if the last file is played
-	auto_delete_file = true, -- (*true | false)
+	autoDeleteFile = "yes", -- (*yes | no)
 	-- The type of playlist, used for processing defaults internally. Default is "auto" and makes the script check it
 	-- This list of filetypes is arbitrary and "auto" will allow for parsing anything that has a parser script available
-	playlist_type = "auto", -- ("txt" | *"auto" | the name of any of the existing parsers)
+	playlistType = "auto", -- ("txt" | *"auto" | the name of any of the existing parsers)
 	-- The playlist file. Due to limitations in the Lua env, this needs to be passed as a script-opt.
 	-- This playlist is parsed internally and only parses playlist types for which a parser is available.
 	playlist = "None", -- ("None" | "[/path/to/]<playlist_file.ext>")
 	-- Whether to create the playlist file if it doesn't exist yet
-	create_file = false, -- (true | *false)
+	createFile = "no", -- (yes | *no)
 	-- Emergency exit option. The only use-case is when people set up a config file for this script
 	-- that sets a default playlist file to load and either
-	-- create_file=true or has mpv running with --idle=[once | yes]
+	-- createFile=true or has mpv running with --idle=[once | yes]
 	-- or if the playlist file already exists and is set in the config
-	exit = false
+	exit = "no" -- (yes | *no)
 }
 opts.read_options(options, "yeetpls")
+for k,v in pairs(options) do
+	print("Key: "..k.."; Value: "..tostring(v))
+end
 
 -- Basic initialization. Wrapped in a function so we can properly exit the script if anything fails
 function base_init()
-	if options.playlist_type == "auto" then -- Determine the type of playlist, this is based on the extension
+	if options.playlistType == "auto" then -- Determine the type of playlist, this is based on the extension
 		filetype = options.playlist:reverse():match('.*%p'):reverse():sub(2)
 		msg.info("Reading playlist of type "..filetype)
-		options.playlist_type = filetype
+		options.playlistType = filetype
 		-- More than willing to accept PRs that add tables to map extensions to playlist types,
 		-- in order to allow one parser to be used with any legal file type extension
 	else
-		filetype = options.playlist_type -- It's expected that users know what they're doing when setting this opt
+		filetype = options.playlistType -- It's expected that users know what they're doing when setting this opt
 		-- If you named your file "some.esoteric.format.kekw", but it's just plaintext, don't touch this.
 		-- If it's anything that just lists a file per line like it's `ls`, leave this option alone.
 		-- By default, it tries to parse unknown filetypes as `txt`
@@ -68,10 +71,10 @@ function base_init()
 	end
 	-- Open the file for appending and reading, this tests for both read and write permissions.
 	local pls_file,err,errcode = nil,nil,nil
-	if not options.create_file then
+	if options.createFile ~= "yes" then
 		pls_file,err,errcode = io.open(options.playlist, "r")
 		if err then
-			msg.error("File '"..options.playlist.."' does not exist and create_file script-opt was not set to true. Exiting...")
+			msg.error("File '"..options.playlist.."' does not exist and createFile script-opt was not set to 'yes'. Exiting...")
 			return false
 		end
 		pls_file:close()
@@ -85,23 +88,28 @@ function base_init()
 		pls_file:close() -- Close the file properly
 		mpv_pls = mp.get_property_native("playlist") -- Array of objects => indexed table of tables. [{"filename", <file path>}...]
 	end
+	if not parser.test_format(pls_old) then
+		return false
+	end
 	-- Everything was successful, time to actually do stuff here!
 	return true
 end
 
-if options.playlist == "None" or options.exit then -- silently exit
+if options.playlist == "None" or options.exit == "yes" then -- silently exit
 	return
 else
 	if not base_init() then -- something caused a failure, exit.
 		msg.error(parser_name.." was unable to parse this playlist type ("..filetype.."). Exiting...")
 		return
-	elseif #mpv_pls == 0 then
+	elseif #mpv_pls == 0 then -- a playlist file wasn't loaded, so it's empty and idle
 		mp.commandv('loadlist', options.playlist, 'append')
+		-- make seure we get a correct count now
+		mpv_pls = mp.get_property_native("playlist") -- Array of objects => indexed table of tables. [{"filename", <file path>}...]
 	end
 end
 -- If and only if we're successful, create the config file if it doesn't exist yet
 -- If the script is global and the user wants their own custom config, they can do it themselves
-if options.make_config then
+if options.makeConfig == "yes" then
 	-- create the config file and alert the user
 	local config_file = mp.get_script_directory():gsub("scripts[/|\\].*", "script-ops/yeetpls.conf")
 	if mp.get_property_native('options/vo-mmcss-profile', o) ~= o then
@@ -110,36 +118,41 @@ if options.make_config then
 	local file,err,errcode = io.open(config_file, "w+")
 	if err then
 		msg.error("Couldn't create config file, recieved error "..tostring(errcode)..": "..tostring(err))
-		msg.info("To prevent getting this message again, make sure the script can write to '"..config_file.."' or create a default config file for yeetpls that sets make_config=false")
+		msg.info("To prevent getting this message again, make sure the script can write to '"..config_file.."' or create a default config file for yeetpls that sets makeConfig=false")
 	else
-		msg.info("Setting all defaults for the script settings. Using current settings from --script-ops except for make_config, playlist_type and playlist")
+		msg.info("Setting all defaults for the script settings. Using current settings from --script-ops except for makeConfig, playlistType and playlist")
 		file:write("# Config file for the yeetpls Lua script. All options are followed by a comment listing all legal values, the default for the script is indicated with *\n\n")
-		file:write("# Whether or not to (re)create the default config file\nmake_config=false # [true | *false]\n\n")
-		file:write("# Whether or not to delete entries in the playlist file, makes VERY little sense to turn off\nauto_delete_entries="..tostring(options.auto_delete_entries).." # [*true | false]\n\n")
-		file:write("# Whether or not to delete the playlist file after finishing the last file\nauto_delete_file="..tostring(options.auto_delete_files).." # [*true | false]")
-		file:write("# The type of playlist, and by extension what parser, to use. The script can figure this out during runtime.\nplaylist_type=auto # [*auto | txt | ...] make sure this matches one of the *-parser.lua files exactly!")
+		file:write("# Whether or not to (re)create the default config file\nmakeConfig=no # [yes | *no]\n\n")
+		file:write("# Whether or not to delete entries in the playlist file, makes VERY little sense to turn off since it's what the script was made for\nautoDeleteEntries="..tostring(options.autoDeleteEntries).." # [*yes | no]\n\n")
+		file:write("# Whether or not to delete the playlist file after finishing the last file\nautoDeleteFile="..tostring(options.autoDeleteFiles).." # [*yes | no]")
+		file:write("# The type of playlist, and by extension what parser, to use. The script can figure this out during runtime.\nplaylistType=auto # [*auto | txt | ...] make sure this matches one of the *-parser.lua files exactly!")
 		file:write("# Playlist file to load. Setting this here can cause some issues, so be careful!\nplaylist=None # [None | any file path or name you want]")
-		file:write("# Whether or not to create the playlist file if it doesn't already exist. Some edge cases can cause issues.\ncreate_file=false\n\n")
-		file:write("# Emergency option to exit the script without doing anything. THIS SHOULD ONLY BE SET TO TRUE THROUGH --SCRIPT-OPS. Disables the script entirely!\nexit=false\n")
+		file:write("# Whether or not to create the playlist file if it doesn't already exist. Some edge cases can cause issues.\ncreateFile=no # [yes | *no]\n\n")
+		file:write("# Emergency option to exit the script without doing anything. THIS SHOULD ONLY BE SET TO TRUE THROUGH --SCRIPT-OPS. Disables the script entirely!\nexit=no # [*no | *no | *no | yes]\n")
 		-- Files should end with a newline, this is common sense.
 	end
 end
+
+local cur_index = 0
+function get_pls_id(event)
+	cur_index = mp.get_property_native("playlist-pos")
+end
+mp.register_event("start-file", get_pls_id)
 
 local pls_deleted = false -- prevents shutdown from eof before writing to file
 function pls_remove(event)
 	-- If a user quits midway through, don't delete the entry.
 	-- Skipping to next should have another reason according to docs
 	-- Error is an external issue, better not remove the entry so the user can debug
-	if event.reason == "quit" or event.reason == "error" or not options.auto_delete_entries then
+	if event.reason == "quit" or event.reason == "error" or options.autoDeleteEntries ~= "yes" then
 		return
 	end
-	-- Any other reason is a go-ahead to remove
-	local plsID = event.playlist_entry_id
-	-- remove it from the comparison table
-	mpv_pls:remove(plsID)
+	mp.commandv("playlist-remove", tostring(cur_index))
+	mpv_pls = mp.get_property_native("playlist")
+	print(#mpv_pls)
 	-- If the last file finishes playing, reason is still eof
 	-- So check if this was the last entry and if so, delete the playlist file.
-	if #mpv_pls == 0 then
+	if #mpv_pls == 0 and options.autoDeleteFile == "yes" then
 		os.remove(options.playlist)
 		pls_deleted = true
 	end
@@ -148,9 +161,7 @@ mp.register_event("end-file", pls_remove)
 
 function finalize(event)
 	if pls_deleted then
-		-- this is only true if the last file in the playlist was played and
-		-- was skipped or reached eof.
-		-- And skipping to next is impossible on the last file.
+		-- this is only true if the last file in the playlist was played and removed
 		return
 	end
 	if #mpv_pls > 0 then
@@ -162,5 +173,8 @@ function finalize(event)
 		local write_data = parser.format_pls(pls_old, mpv_pls)
 		pls_file:write(write_data) -- It doesn't matter to mpv if there's a newline at the end
 	end
+	mp.unregister_event(pls_remove)
+	mp.unregister_event(get_pls_id)
+	mp.unregister_event(finalize)
 end
 mp.register_event("shutdown", finalize)

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -7,7 +7,7 @@ local parser = nil -- The parser used internally, set during init.
 local parser_name = nil -- This value is only used when stuff errors
 local pls_old = nil -- The old playlist file's content
 local mpv_pls = nil -- populated internally with mpv's playlist
-local pls_deleted = false -- prevents shutdown from eof from writing a new playlist file
+local pls_deleted = false -- prevents shutdown from eof before writing to file
 local options = {
 	-- whether or not to auto-delete playlist entries after playing them
 	auto_delete_entries = true, -- (*true | false)
@@ -34,6 +34,7 @@ function base_init()
 	if options.playlist_type == "auto" then -- Determine the type of playlist, this is based on the extension
 		filetype = options.playlist:reverse():match('.*%p'):reverse():sub(2)
 		msg.info("Reading playlist of type "..filetype)
+		options.playlist_type = filetype
 		-- More than willing to accept PRs that add tables to map extensions to playlist types,
 		-- in order to allow one parser to be used with any legal file type extension
 	else
@@ -95,8 +96,8 @@ else
 		msg.error(parser_name.." was unable to parse this playlist type ("..filetype.."). Exiting...")
 		return
 	else
-		-- TESTING INFO, success!
-		print("loading "..parser_name.." was successful!")
+	if #mpv_pls == 0 then
+		mp.commandv('loadlist', options.playlist, 'append')
 	end
 end
 

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -3,10 +3,11 @@ local opts = require("mp.options")
 local utils = require("mp.utils")
 local msg = require("mp.msg")
 local filetype = nil -- used internally in places for the error state
-local mpv_pls = nil -- populated internally with mpv's playlist, so a list of
-local parser = nil
+local parser = nil -- The parser used internally, set during init.
 local parser_name = nil -- This value is only used when stuff errors
-local pls_old = nil
+local pls_old = nil -- The old playlist file's content
+local mpv_pls = nil -- populated internally with mpv's playlist
+local pls_deleted = false -- prevents shutdown from eof from writing a new playlist file
 local options = {
 	-- whether or not to auto-delete playlist entries after playing them
 	auto_delete_entries = true, -- (*true | false)
@@ -32,14 +33,16 @@ opts.read_options(options, "yeetpls")
 function base_init()
 	if options.playlist_type == "auto" then -- Determine the type of playlist, this is based on the extension
 		filetype = options.playlist:reverse():match('.*%p'):reverse():sub(2)
-		print("Reading playlist of type "..filetype)
+		msg.info("Reading playlist of type "..filetype)
 		-- More than willing to accept PRs that add tables to map extensions to playlist types,
 		-- in order to allow one parser to be used with any legal file type extension
 	else
 		filetype = options.playlist_type -- It's expected that users know what they're doing when setting this opt
-		-- If you named your file "some.esoteric.format.kekw", but it's just plaintext, you'll wanna set this.
+		-- If you named your file "some.esoteric.format.kekw", but it's just plaintext, don't touch this.
 		-- If it's anything that just lists a file per line like it's `ls`, leave this option alone.
 		-- By default, it tries to parse unknown filetypes as `txt`
+		-- This is mostly a development option for testing new parsers and speeding things up.
+		-- Use this if you know exactly what parser you need to skip all checks on it.
 	end
 	-- Not sure what happens if I define a new variable and use an existing one,
 	-- better make sure both exist.
@@ -48,16 +51,32 @@ function base_init()
 	hasparser,parser = pcall(require, filetype.."-parser")
 	if not hasparser then
 		-- default to the txt-parser
+		msg.warn("No "..filetype.."-parser.lua found, trying to parse as text file")
 		parser = require("txt-parser")
 		parser_name = "txt-parser"
+		-- Perform a special check in txt-parser.lua to see if this is a plaintext playlist.
+		-- This is _only_ done for the txt-parser as it's the base to build on and the only feasible check.
+		if not parser.check_txt(options.playlist) then
+			msg.error("txt-parser was unable to process this file. Exiting...")
+			return false
+		end
 	else
 		-- We have a parser, save the name in case of errors
 		parser_name = filetype.."-parser"
 	end
 	-- Open the file for appending and reading, this tests for both read and write permissions.
-	local pls_file,err,errcode = io.open(options.playlist, "a+")
-	if err then -- We don't have read and/or write, error and exit
-		print("Recieved error code "..errcode..": "..err..".\nCannot process playlist, exiting...")
+	local pls_file,err,errcode = nil,nil,nil
+	if not options.create_file then
+		pls_file,err,errcode = io.open(options.playlist, "r")
+		if err then
+			msg.error("File '"..options.playlist.."' does not exist and create_file script-opt was not set to true. Exiting...")
+			return false
+		end
+		pls_file:close()
+	end
+	pls_file,err,errcode = io.open(options.playlist, "a+")
+	if err then -- We don't have write access, error and exit
+		msg.error("Recieved error code "..errcode..": "..err..".\nCannot process playlist, exiting...")
 		return false
 	else
 		pls_old = pls_file:read("*all") -- Save the old playlist, should be fairly small
@@ -69,14 +88,53 @@ function base_init()
 end
 
 if options.playlist == "None" then
-	print("No playlist given to the --script-opts=yeetpls=<playlist file> switch. Exiting extension...")
+	msg.error("No playlist given to the --script-opts=yeetpls-playlist=<playlist file> switch. Exiting extension...")
 	return
 else
 	if not base_init() then -- something caused a failure, exit.
-		print(parser_name.." was unable to parse this playlist type ("..filetype.."). Exiting...")
+		msg.error(parser_name.." was unable to parse this playlist type ("..filetype.."). Exiting...")
 		return
 	else
 		-- TESTING INFO, success!
 		print("loading "..parser_name.." was successful!")
 	end
 end
+
+function pls_remove(event)
+	-- If a user quits midway through, don't delete the entry.
+	-- Skipping to next should have another reason according to docs
+	-- Error is an external issue, better not remove the entry so the user can debug
+	if event.reason == "quit" or event.reason == "error" then
+		return
+	end
+	-- Any other reason is a go-ahead to remove
+	local plsID = event.playlist_entry_id
+	-- If the last file finishes playing, reason is still eof
+	-- So check if this was the last entry and if so, delete the playlist file.
+	if #mpv_pls <= 1 then
+		os.remove(options.playlist)
+		pls_deleted = true
+	end
+	-- remove it from the comparison table
+	mpv_pls:remove(plsID)
+end
+mp.register_event("end-file", pls_remove)
+
+function finalize(event)
+	if pls_deleted then
+		-- this is only true if the last file in the playlist was played and
+		-- was skipped or reached eof.
+		-- And skipping to next is impossible on the last file.
+		return
+	end
+	if #mpv_pls > 0 then
+		local pls_file,err,errcode = io.open(options.playlist, "w+")
+		if err then
+			msg.error("Ran into an unexpected problem opening '"..options.playlist.."', can't write playlist! Exiting...")
+			return
+		end
+		local write_data = parser.format_pls(pls_old, mpv_pls)
+		pls_file:write(write_data) -- It doesn't matter to mpv if there's a newline at the end
+	end
+end
+mp.register_event("shutdown", finalize)

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -46,7 +46,7 @@ function base_init()
 	end
 	-- Not sure what happens if I define a new variable and use an existing one,
 	-- better make sure both exist.
-	local hasparser = nil
+	local hasparser = false
 	-- Test if we have a parser for this
 	hasparser,parser = pcall(require, filetype.."-parser")
 	if not hasparser then

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -108,15 +108,15 @@ if options.make_config then
 		config_file = config_file:gsub("/", "\\")
 	end
 	local file,err,errcode = io.open(config_file, "w+")
-	if not err then
-		msg.error("Couldn't create config file, recieved error "..errcode..": "..err)
+	if err then
+		msg.error("Couldn't create config file, recieved error "..tostring(errcode)..": "..tostring(err))
 		msg.info("To prevent getting this message again, make sure the script can write to '"..config_file.."' or create a default config file for yeetpls that sets make_config=false")
 	else
 		msg.info("Setting all defaults for the script settings. Using current settings from --script-ops except for make_config, playlist_type and playlist")
 		file:write("# Config file for the yeetpls Lua script. All options are followed by a comment listing all legal values, the default for the script is indicated with *\n\n")
 		file:write("# Whether or not to (re)create the default config file\nmake_config=false # [true | *false]\n\n")
-		file:write("# Whether or not to delete entries in the playlist file, makes VERY little sense to turn off\nauto_delete_entries="..options.auto_delete_entries.." # [*true | false]\n\n")
-		file:write("# Whether or not to delete the playlist file after finishing the last file\nauto_delete_file="..options.auto_delete_files.." # [*true | false]")
+		file:write("# Whether or not to delete entries in the playlist file, makes VERY little sense to turn off\nauto_delete_entries="..tostring(options.auto_delete_entries).." # [*true | false]\n\n")
+		file:write("# Whether or not to delete the playlist file after finishing the last file\nauto_delete_file="..tostring(options.auto_delete_files).." # [*true | false]")
 		file:write("# The type of playlist, and by extension what parser, to use. The script can figure this out during runtime.\nplaylist_type=auto # [*auto | txt | ...] make sure this matches one of the *-parser.lua files exactly!")
 		file:write("# Playlist file to load. Setting this here can cause some issues, so be careful!\nplaylist=None # [None | any file path or name you want]")
 		file:write("# Whether or not to create the playlist file if it doesn't already exist. Some edge cases can cause issues.\ncreate_file=false\n\n")

--- a/yeetpls/main.lua
+++ b/yeetpls/main.lua
@@ -1,0 +1,48 @@
+-- local mp already exists. Preloaded by mpv itself
+local opts = require("mp.options")
+local utils = require("mp.utils")
+local msg = require("mp.msg")
+local parser = nil
+local options = {
+	-- The OS type, or an approximation anyway. auto makes the script check it
+	system = "auto",
+	-- whether or not to auto-delete playlist entries after playing them
+	auto_delete_entries = true, -- (*true | false)
+	-- Whether to delete the playlist file if the last file is played
+	auto_delete_file = true, -- (*true | false)
+	-- Print info like playlist length and title when starting
+	info_on_start = true, -- (*true | false)
+	-- Print info like remaining titles and title on the next entry
+	info_on_next = false, -- (true | *false)
+	-- The type of playlist, used for processing defaults internally. Default is "auto" and makes the script check it
+	-- This list of filetypes is arbitrary and "auto" will allow for parsing anything that has a parser script available
+	playlist_type = "auto", -- ("txt" | "m3u" | "m3u8" | "pls" | *"auto")
+	-- The playlist file. Due to limitations in the Lua env, this needs to be passed as a script-opt.
+	-- This playlist is parsed internally and only parses playlist types for which a parser is available.
+	playlist = "None" -- ("None" | "[/path/to/]<playlist_file.ext>")
+}
+opts.read_options(options, "yeetpls")
+
+function base_init()
+	--check OS type, borrowed from https://github.com/jonniek/mpv-playlistmanager/blob/8f01f38d71bdf02a3b61988a940a5fc0db3b573c/playlistmanager.lua#L171
+	if options.system=="auto" then
+	  local o = {}
+	  if mp.get_property_native('options/vo-mmcss-profile', o) ~= o then
+	    options.system = "windows"
+	  else
+	    options.system = "linux"
+	  end
+	end
+	if options.playlist_type == "auto" then
+		local filetype = options.playlist:reverse():match('.*%p'):reverse():sub(2)
+		print("Reading playlist of type "..filetype)
+		parser = require(filetype.."-parser")
+	end
+end
+
+if not options.playlist == "None" then
+	print("No playlist given in the form of --script-opts=yeetpls-playlist=playlist.ext\n\tExiting extension...")
+	return
+else
+	base_init()
+end

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -1,0 +1,1 @@
+-- Work in progress

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -19,7 +19,8 @@ local full_winpath = "(%a:\\)?(([\w,\s;-]+(%.+)?)+\\)*([\w,\s;\.-]+(\.(%a+))?$)"
 -- Uses forward slashes instead of >Windows backslashes
 -- Allows escaped whitespace. Most often encountered on files made on a Windows
 -- 		machine, or mounted NTFS drives. Dual boot system pain
-local full_path = "/(([\w-]+(\\\s)*(%.+)?)+/)*([\w\.-]+(\\\s)*(\.(%a+))?$)"
+-- 		Escaping whitespace might not be necessry for applications.
+local full_path = "/(([\w-]+((\\)?\s)*(%.+)?)+/)*([\w\.-]+((\\)?\s)*(\.(%a+))?$)"
 local mpv_tbl
 
 -- Check if a value is a playlist entry. v[1] is "filename" or similar, v[2] is the entry

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -15,14 +15,14 @@ local parser = {}
 -- 		or it could be a relative path. Handles multiple periods in succession
 -- 		so it allows relative paths like ..\ as well folder names with more than
 -- 		one period in succession
--- ([\w,\s;-]+(\.(%a+))?$) = Match all valid filenames, optionally without extension
+-- ([\w,\s;-]+(%.(%a+))?$) = Match all valid filenames, optionally without extension
 -- 		Filename with extension must be the end of it
-local full_winpath = "(%a:\\)?(([\w,\s;-]+(%.+)?)+\\)*([\w,\s;\.-]+(\.(%a+))?$)"
+local full_winpath = "(%a:((\\)|(/)))?(([\w,\s;-]+(%.+)?)+((\\)|(/)))*([\w,\s;%.-]+(%.(%a+))?$)"
 -- Uses forward slashes instead of >Windows backslashes
 -- Allows escaped whitespace. Most often encountered on files made on a Windows
 -- 		machine, or mounted NTFS drives. Dual boot system pain
 -- 		Escaping whitespace might not be necessry for applications.
-local full_path = "/(([\w-]+((\\)?\s)*(%.+)?)+/)*([\w\.-]+((\\)?\s)*(\.(%a+))?$)"
+local full_path = "/(([\w-]+((\\)?\s)*(%.+)?)+/)*([\w%.-]+((\\)?\s)*(%.(%a+))?$)"
 local mpv_tbl
 
 -- Check if a value is a playlist entry. v[1] is "filename" or similar, v[2] is the entry
@@ -71,15 +71,15 @@ function parser.test_format(pls)
 	-- 		or it could be a relative path. Handles multiple periods in succession
 	-- 		so it allows relative paths like ..\ as well as folder names with more than
 	-- 		one period in succession
-	-- ([\w,\s;-]+(\.(%a+))?$) = Match all valid filenames, optionally without extension
+	-- ([\w,\s;-]+(%.(%a+))?$) = Match all valid filenames, optionally without extension
 	-- 		File name with extension must be the end of it
-	local winpaths = "(%a:\\)?(([\w,\s;-]+(%.+)?)+\\)*([\w,\s;\.-]+(\.(%a+))?$)"
+	local winpaths = "(%a:\\)?(([\w,\s;-]+(%.+)?)+\\)*([\w,\s;%.-]+(%.(%a+))?$)"
 	local default_to_win = false
 	-- Uses forward slashes instead of >Windows backslashes
 	-- Allows escaped whitespace. Most often encountered on files made on a Windows
 	-- 		machine, or mounted NTFS drives. Dual boot system pain
 	-- 		Escaping whitespace might not be necessry for applications.
-	local paths = "(/)?(([\w-]+((\\)?\s)*(%.+)?)+/)*([\w\.-]+((\\)?\s)*(\.(%a+))?$)"
+	local paths = "(/)?(([\w-]+((\\)?\s)*(%.+)?)+/)*([\w%.-]+((\\)?\s)*(%.(%a+))?$)"
 	-- If we don't encounter anything weird, this stays true and we exit
 	local pass = true
 	local entries = split_entries(pls)
@@ -102,14 +102,6 @@ function parser.test_format(pls)
 		end
 	end
 	return pass -- All entries passed the test, playlist is correct.
-end
-
-function parser.load_pls(pls)
-	local ret = {}
-	for i,v in ipairs(split_entries(pls)) do
-		ret:insert(v)
-	end
-	return ret
 end
 
 -- Return the module for use in main.lua

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -1,1 +1,53 @@
--- Work in progress
+-- In order to test the input file for a variety of options, we'll need to also
+-- take the OS-specific paths into account and the accepted ways of matching
+-- files and paths. Which in Windows allows both forward and backward slashes
+-- in most if not all cases.
+-- Obviously this means making special cases for Windows. REEE
+
+local parser = {}
+
+-- Checks all valid chars in filepaths. Allows for periods in paths, allows no extension
+-- (%a:\\)? = Drive letter, may occur once
+-- (([\w,\s;-]+(%.+)?)+\\)* = Valid folder names, with periods. Add a backslash.
+-- 		May occur an arbitrary number of times, file could be in the drive root
+-- 		or it could be a relative path. Handles multiple periods in succession
+-- 		so it allows relative paths like ..\ as well folder names with more than
+-- 		one period in succession
+-- ([\w,\s;-]+(\.(%a+))?$) = Match all valid filenames, optionally without extension
+-- 		Filename with extension must be the end of it
+local full_winpath = "(%a:\\)?(([\w,\s;-]+(%.+)?)+\\)*([\w,\s;\.-]+(\.(%a+))?$)"
+-- Uses forward slashes instead of >Windows backslashes
+-- Allows escaped whitespace. Most often encountered on files made on a Windows
+-- 		machine, or mounted NTFS drives. Dual boot system pain
+local full_path = "/(([\w-]+(\\\s)*(%.+)?)+/)*([\w\.-]+(\\\s)*(\.(%a+))?$)"
+local mpv_tbl
+
+-- Check if a value is a playlist entry. v[1] is "filename" or similar, v[2] is the entry
+function in_mpv(val)
+	for i,v in ipairs(mpv_tbl) do
+		if val == v[2] then
+			return true
+		end
+	end
+	return false
+end
+
+-- Create the required functions within parser
+function parser.format_pls(pls_in, mpv_pls)
+	-- Split the entries by newlines, these can be '\r', '\n' or '\r\n'
+	local pls_tbl = pls_in:gmatch("(\r\n)|(\r)|(\n)")
+	mpv_tbl = mpv_pls
+	-- As strings are immutable, we'll leverage table.concat instead
+	local pls_out = {}
+	for i,v in ipairs(pls_tbl) do
+		if in_mpv(v) then
+			-- Yay, the value is still in the mpv playlist. Add it to the table
+			pls_out:insert(v)
+		end
+	end
+	-- Return the playlist as a concatenated string
+	return pls_out:concat("\n")
+end
+
+-- Return the module's functions for use in main.lua
+return parser

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -3,6 +3,8 @@
 -- files and paths. Which in Windows allows both forward and backward slashes
 -- in most if not all cases.
 -- Obviously this means making special cases for Windows. REEE
+-- This also means that if you mix-and-match Windows paths and POSIX-compliant
+-- paths, the parser will deem your playlist unparsable. Deal with it.
 
 local parser = {}
 
@@ -33,6 +35,12 @@ function in_mpv(val)
 	return false
 end
 
+-- Split all entries in the playlist file.
+-- Even though it's just newlines for this, it makes for a nice skeleton for other parsers.
+function split_entries(pls)
+	return pls:gmatch("(\r\n)|(\r)|(\n)")
+end
+
 -- Create the required functions within parser
 function parser.format_pls(pls_in, mpv_pls)
 	-- Split the entries by newlines, these can be '\r', '\n' or '\r\n'
@@ -50,5 +58,59 @@ function parser.format_pls(pls_in, mpv_pls)
 	return pls_out:concat("\n")
 end
 
--- Return the module's functions for use in main.lua
+-- Test if the input format matches the expected input and return a Boolean.
+-- Do this however seems most fit for the parser you wrote.
+-- It is recommended to import this function into all other parsers to test
+-- if the file paths are actually valid.
+-- I'll deal with adding net streams later
+function parser.test_format(pls)
+	-- Checks all valid chars in file paths. Allows for periods in paths, allows no extension
+	-- (%a:\\)? = Drive letter, may occur once
+	-- (([\w,\s;-]+(%.+)?)+\\)* = Valid folder names, with periods. Add a backslash.
+	-- 		May occur an arbitrary number of times, file could be in the drive root
+	-- 		or it could be a relative path. Handles multiple periods in succession
+	-- 		so it allows relative paths like ..\ as well as folder names with more than
+	-- 		one period in succession
+	-- ([\w,\s;-]+(\.(%a+))?$) = Match all valid filenames, optionally without extension
+	-- 		File name with extension must be the end of it
+	local winpaths = "(%a:\\)?(([\w,\s;-]+(%.+)?)+\\)*([\w,\s;\.-]+(\.(%a+))?$)"
+	local default_to_win = false
+	-- Uses forward slashes instead of >Windows backslashes
+	-- Allows escaped whitespace. Most often encountered on files made on a Windows
+	-- 		machine, or mounted NTFS drives. Dual boot system pain
+	-- 		Escaping whitespace might not be necessry for applications.
+	local paths = "(/)?(([\w-]+((\\)?\s)*(%.+)?)+/)*([\w\.-]+((\\)?\s)*(\.(%a+))?$)"
+	-- If we don't encounter anything weird, this stays true and we exit
+	local pass = true
+	local entries = split_entries(pls)
+	local t = {}
+	for index,entry in ipairs(entries) do
+		if not default_to_win then
+			if not entry:find(paths) then
+				if not entry:find(winpaths) then
+					pass = false
+					break
+				else
+					default_to_win = true
+				end
+			end
+		else
+			if not entry:find(winpaths) then
+				pass = false
+				break
+			end
+		end
+	end
+	return pass -- All entries passed the test, playlist is correct.
+end
+
+function parser.load_pls(pls)
+	local ret = {}
+	for i,v in ipairs(split_entries(pls)) do
+		ret:insert(v)
+	end
+	return ret
+end
+
+-- Return the module for use in main.lua
 return parser


### PR DESCRIPTION
Adding in the first fully functional script: yeetpls, an alternative playlist loader and script to remove playlist entries as you watch them. The main goal is for watching series and removing watched entries from the playlist so you don't have to manually edit them out or use some playlist manager. Just sit back and watch and hit `q` when you're shutting down like you're used to. The script handles the rest!