### PR TITLE
Added pls-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Then after pondering how to do this, I figured I might as well write some script
 If the script doesn't exist yet, expect a branch to be made soon™. If you have suggestions, feel free to fork or [contact me](#Contact) about it!
 |    Name    |                Description                |
 |------------|-------------------------------------------|
-| yeetpls    | Delete playlist entries after playing them, or the entire playlist file when done |
+| [yeetpls](/yeetpls) | Delete playlist entries after playing them, or the entire playlist file when done |
 
 # Installing #
 For any and all of the scripts, they work as all mpv user scripts work. You put them in the global or user-local scripts directory. Information
@@ -44,7 +44,7 @@ Branches in this repo will be ordered a bit different from most projects because
 - If you wish to contribute to this repo rather than fork, [shoot me a message](#Through-Discord) and we'll see if I can add you;
   - It's advisable to have sent in PRs before you request being added to the repo as a contributor.
   - In some cases of ~~favoritism~~ personal contacts, I'll add people I know and have faith in to write good code.
-- For more info on script collections (for example [`yeetpls`](/yeetpls)), look at the README in the top-level folder.
+- For more info on script collections (for example `yeetpls`), look at the README in the top-level folder.
 
 # Contact #
 ## Through GitHub ##

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Branches in this repo will be ordered a bit different from most projects because
 - If a script is deemed stable and complete, the branch will be deleted after 9 weeks of inactivity;
 - If you wish to contribute to this repo rather than fork, [shoot me a message](#Through-Discord) and we'll see if I can add you;
   - It's advisable to have sent in PRs before you request being added to the repo as a contributor.
-  - In some cases of ~~favoritism~~ personal contacts, I'll add people I know and have faith in to write good code
+  - In some cases of ~~favoritism~~ personal contacts, I'll add people I know and have faith in to write good code.
+- For more info on script collections (for example [`yeetpls`](/yeetpls)), look at the README in the top-level folder.
 
 # Contact #
 ## Through GitHub ##

--- a/README.md
+++ b/README.md
@@ -31,8 +31,13 @@ throw errors. And that gives you those scary red messages on the CLI that make y
 Branches in this repo will be ordered a bit different from most projects because I want to make contributing easy for all. And since this repo is supposed to be a collection, we don't want to accidentally push changes to an unstable file when another one has a stable update.
 
 `master` is the classical branch for the stable versions of the script. Shouldn't change unless working updates are made. What's in here can be downloaded safely. Then there's the matter of adding new scripts or changing existing ones. This should be done by creating a branch named after the script. A few simple rules for both:
-- Branch and Script names will be all lower case, with dashes or underscores to separate words;
-- The choice between a dash or underscore is a free choice for whomever makes it; (both `yeet-pls` and `yeet_pls` are valid)
+- Branch names will be all lower case, with underscores to separate words.
+- Script names will be in camelCase, or as a single string.
+  - Both `yeetpls` and `yeetPls` are valid;
+  - `yeetpls` is preferred for ease of use on the CLI
+  - Reflect this in the branch name using underscores
+  - Use camelCase only if it's an important distinction to be made
+    - expertsexchange is somewhat ambiguous, expertsExchange is not.
 - Changes to a script should **only** be made in the branch of the same name;
 - If a branch doesn't exist, create it;
 - If a script is deemed stable and complete, the branch will be deleted after 9 weeks of inactivity;

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -33,7 +33,7 @@ Feel free to suggest other ways of attempting to get the file though!
 _Behavior for this problem might change to instead attempt to load the playlist from just the script-opt and having the user add the flag to not close on idling. This remains to be seen as it changes
 the requirements to parsers as well, to read playlists on start and parse them to a table instead of just the other way around. Imagine the extra effort this would take_
 
-## Parsers ##
+## Adding New Parsers ##
 A new parser for a type of playlist files should provide at least two functions:
 - `format_pls`:
 	- Arguments given to a parser are always the same, in the given order:
@@ -66,4 +66,4 @@ A new parser for a type of playlist files should provide at least two functions:
 **Make sure to add these to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
 
 Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
-So long as it translates between mpv's internal playlist objects and the type of playlist it processes, this code is gonna be happy with it.
+So long as it translates between mpv's internal playlist objects and the type of playlist it processes, [this code](./main.lua) is gonna be happy with it.

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -8,7 +8,8 @@ This script does not care about where it's being run from. So long as mpv can re
 
 ## Usage Notes ##
 Due to a [limitation in mpv](#Known-Issues), you must pass the playlist file to `--script-ops=yeetpls-playlist=<file>`. Thanks to the `loadlist` internal input command, this script can **replace**
-the need for an input file or the use of the `--playlist` option.
+the need for an input file or the use of the `--playlist` option. My own command is usually `mpv --idle=once --script-opts=yeetpls-playlist=playlist.txt`. Setting `idle=once` (or `yes`) is a hard
+requirement here, because mpv will **__NOT__** init any scripts if it's not allowed to idle. You could also set this option in your mpv.conf so that `--idle=once` is always applied.
 Optionally also pass the script-opt `create_file=true` if it doesn't exist and you want it to be made. _If it doesn't exist and you don't pass this option, it **will** error and exit._
 Current behavior is to bypass read check on the file and immediately open it in `a+` for reading, appending and creating.
 
@@ -46,7 +47,7 @@ A new parser for a type of playlist files should provide at least two functions:
 	- The value returned should be a string that can be written to a playlist file, according to the playlist spec.
 - `test_format`:
 	- Argument given for this function is always just the content of the file.
-	- The value returned should be a boolean.
+	- The value returned should be a Boolean.
 	- If multiple format specs allow for the same parser to be used (m3u/m3u8 for example), an extra step is required:
 		- Mention this in any PR to add functionality
 		- Provide a list of all formats that match
@@ -59,11 +60,13 @@ A new parser for a type of playlist files should provide at least two functions:
 		- Not dropping fields that could fairly easily be implemented
 		- If a file takes note of URL/local file/webstream, please try to match this in the output
 	- Do not throw errors if a file is a mismatch to the spec
-		- Either use `print` or `mp.msg.warn` to notify the user of this.
+		- Use one of the `mp.msg` functions to notify the user of this.
 		- Optionally print a single line message on the OSD
 		- `return false` makes main.lua attempt to use a fallback, if that fails it provides a clean exit.
+		- This fallback may or may not break the entire input file, I might change this behavior later.
 
-**Make sure to add these to the module's exported function list**. The parser will be `require`d dynamically so if you don't expose `parser.format_pls`, it can't be used.
+**Make sure to add these to the module's exported function list**. The parser will be `require`d as `parser=require(type.."-parser")`, so if you don't expose `parser.format_pls`, it can't be used.
+Anything else you add to the module's export list will be ignored by `main.lua`.
 
 Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
 So long as it translates between mpv's internal playlist objects and the type of playlist it processes, [this code](./main.lua) is gonna be happy with it.

--- a/yeetpls/README.md
+++ b/yeetpls/README.md
@@ -15,7 +15,7 @@ Current behavior is to bypass read check on the file and immediately open it in 
 
 This script assumes that **there is no shuffle applied**. It was made with the intention of automating the entire process from acquiring anime down to watching the show without doing anything
 other than pointing mpv to a playlist. I personally set up a simple script to run on download completion that automatically generates a file `playlist.txt` which is just a list of file names
-in the directory that don't match certain patterns. If you apply shuffle, make sure that the playlist format you use gets processed by a parser that actually filters the entries by comparison.
+in the directory that don't match certain patterns. If you apply shuffle, make sure that the playlist format you use gets processed by a parser that [isn't affected by shuffle](#Supported-Formats).
 The `txt` parser is guaranteed to provide this functionality, because the file format is extremely easy to use and the largest workload is extracting all remaining file names.
 Creating a playlist for it is as easy as redirecting the output of `ls` (or `dir` with the correct flags under Windows) to a text file,
 or just aggregating all full paths for the media you want in it in a single file. One playlist entry per line, as per mpv's plaintext playlist handler.
@@ -70,3 +70,10 @@ Anything else you add to the module's export list will be ignored by `main.lua`.
 
 Whatever else these parsers do internally is irrelevant, make them perform black magic for all I care.
 So long as it translates between mpv's internal playlist objects and the type of playlist it processes, [this code](./main.lua) is gonna be happy with it.
+
+## Supported Formats ##
+_Parsers will never remove entries that have not been played. If they're not Shuffle-safe, ouput will be the same as the shuffled playback order for mpv internally._
+| Parser | Formats | Shuffle-safe |
+|--------|---------|--------------|
+| txt-parser | txt, simple m3u. Basically just a list of files.| Yes |
+| pls-parser | pls | Yes |

--- a/yeetpls/filelist.txt
+++ b/yeetpls/filelist.txt
@@ -1,2 +1,6 @@
+# Main script, this requires at least the txt-parser. Feel free to delete any other parsers if you'll never use them
 main.lua
+# This is a HARD requirement, not just in main, but can be referenced from other parsers as well
 txt-parser.lua
+# Very common filetype for playlists, recommended to have
+pls-parser.lua

--- a/yeetpls/pls-parser.lua
+++ b/yeetpls/pls-parser.lua
@@ -1,0 +1,95 @@
+-- Simple parser for PLS files. Removes blank lines from the input.
+-- This thing basically checks if the format is correct,
+-- extracts all of the info and verifies file names and URLs by
+-- shoving them into a list and having txt-parser deal with it.
+
+-- Used for some lazy parsing, once again let mpv handle retarded entries, so
+-- long as the format is valid
+txt_base = require("txt-parser")
+parser = {}
+
+--- Split all entries in the playlist file
+-- Takes into account the optional nature of
+-- the Title and Length headers.
+function split_entries(pls)
+	-- retain newlines for verification at a later point in time
+	local entryfile = "File%d=.-[\r\n]+"
+	local entrytitle = "Title%d=.-[\r\n]+"
+	local entrylength = "Length%d=%-?%d+[\r\n]+"
+
+	-- Fetch a table of all lines in the file
+	local entries = {}
+	local total_entries = 0
+	-- Remove the header and footer
+	pls = pls:gsub("^%[playlist%][\r\n]-[^\r\n]"):gsub("[\r\n]+NumberOfEntries=%d+[\r\n]+Version=2[\r\n]*")
+	-- Find a way to split on any combination of the above patterns
+	-- gmatch every pattern, get the entry number and use that to get it in the table
+	for match in pls:gmatch(entryfile) do
+		local number = tonumber(pls:match("File%d+"):match("%d+"))
+		entries[number] = match -- This is just the seed, hence why we can't concat it yet
+		total_entries = total_entries + 1
+	end
+	for match in pls:gmatch(entrytitle) do
+		local number = tonumber(pls:match("Title%d+"):match("%d+"))
+		entries[number] = entries[number]..match -- This is just the seed, hence why we can't concat it yet
+	end
+	for match in pls:gmatch(entrylength) do
+		local number = tonumber(pls:match("Length%d+"):match("%d+"))
+		entries[number] = entries[number]..match -- This is just the seed, hence why we can't concat it yet
+	end
+	return entries, total_entries
+end
+
+--- Verifies a compliant PLS header and the fact that it occurs only once
+-- throughout the entire playlist.
+-- Allows [playlist] in a filename, as it checks for the entry to be the only
+-- occurrence on the entire line
+-- @param pls The contents of the entire playlist file in a string
+function verify_header(pls)
+	local header = "^%[playlist%]$"
+	local count = 0
+	local pls_lines = txt_base.split_entries(pls)
+	for _,line in ipairs(pls_lines) do
+		if pls:find(header) then
+			count = count + 1
+		end
+	end
+	-- If there were more than 1 header, or no headers at all, this is invalid
+	if count > 1 or count == 0 then
+		return false
+	end
+	local fileheader = pls:match("^%[playlist%][\r\n]+")
+	return true, fileheader
+end
+
+--- Verifies that the footer in the file is compliant to the spec, and
+-- that it occurs only once. No need to check entries as the format for the
+-- footer disables this option altogether.
+-- Also verifies the NumberOfEntries property has a correct count
+function verify_footer(pls, entries)
+	local footer = "[\r\n]+NumberOfEntries=%d+[\r\n]+Version=2[\r\n]*"
+	local count = select(2, pls:gsub(footer, ""))
+	if count > 1 or count == 0 then
+		return false
+	end
+	local number = tonumber(pls:match("NumberOfEntries=%d+"):match("%d+"))
+	if not entries == number then
+		return false
+	end
+	local filefooter = pls:match("[\r\n]+NumberOfEntries=%d+[\r\n]+Version=2[\r\n]*$")
+	return true, filefooter
+end
+
+function parser.test_format(pls)
+	local header_pass, header = verify_header(pls)
+	local content, total = split_entries(pls)
+	local footer_pass, footer = verify_footer(pls, total)
+	if footer_pass and header_pass then
+		local reconstruct = header..table.concat(content, "")..footer
+		if reconstruct == pls then -- Not stripping any newlines and other data should mean they're equal
+			return true
+		else
+			return false
+		end
+	end
+end

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -2,9 +2,7 @@
 -- take the OS-specific paths into account and the accepted ways of matching
 -- files and paths. Which in Windows allows both forward and backward slashes
 -- in most if not all cases.
--- Obviously this means making special cases for Windows. REEE
--- This also means that if you mix-and-match Windows paths and POSIX-compliant
--- paths, the parser will deem your playlist unparsable. Deal with it.
+-- Luckily new patterns have been set up that allow for both, interchangeably
 
 local parser = {}
 local mpv_tbl
@@ -71,9 +69,10 @@ function parser.test_format(pls)
 	for index,entry in ipairs(entries) do
 		if not entry:find("[^%z<>:%|%?%*\"]") then -- This path contains disallowed chars. Win == NIX here, due to effort and media should work everywhere.
 			pass=false
-		elseif not entry:find(fwp) or not entry:find(fnp) or not entry:find(rfp) or not entry:find(jaf) -- check for paths here. If we don't find them...
-			if not entry:find(upe) -- check for URLs. If none:
+		elseif not entry:find(fwp) or not entry:find(fnp) or not entry:find(rfp) or not entry:find(jaf) then -- check for paths here. If we don't find them...
+			if not entry:find(upe) then -- check for URLs. If none:
 				pass=false -- it matches no known inputs
+			end
 		end
 	end
 	return pass -- All entries passed the test, playlist is correct if this is true.

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -64,7 +64,7 @@ function parser.test_format(pls)
 	local entries = split_entries(pls)
 	local t = {}
 	for index,entry in ipairs(entries) do
-		if entry:find("%z") then -- This filename contains the NULL character. This is universally not allowed
+		if entry:find("[^%z<>:%|%?%*\"]") then -- This filename contains the NULL character. This is universally not allowed
 			pass=false
 		end
 	end

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -72,28 +72,19 @@ function parser.test_format(pls)
 	local entries = split_entries(pls)
 	local t = {}
 	for index,entry in ipairs(entries) do
-		if not entry:find(illegal) then -- This path contains disallowed chars. Win == NIX here, due to effort. And media should work everywhere.
-			pass=false
-		elseif not entry:find(fwp) or not entry:find(fnp) or not entry:find(rfp) or not entry:find(jaf) then -- check for paths here. If we don't find them...
-			pass=false -- it matches no known inputs
-		end
-	end
-	-- This might just be a legal URL, they have different allowed and illegal chars than files
-	if not pass and not entry:find(url_illegal) then
-		if entry:find(upe) then
-			pass = true
-		end
+		if parser.test_entry(entry) then pass = true end
 	end
 	return pass -- All entries passed the test, playlist is correct if this is true.
 end
 
 --- Special function exposed for other parsers that want to test a single
 -- file name / path / URL rather than the entire playlist
+-- I'm sure it's bugged as hell
 -- @param entry The entry to test
 -- @param[opt="all"] test Type of entry to check, use "all" for unknown.
 -- Valid values are "all", "file", "path", "relative", "url"
 -- @return Whether or not this matches any of the patterns requested.
-function parser.testentry(entry, test)
+function parser.test_entry(entry, test)
 	local types = {
 		file = {jaf},
 		path = {fnp, fwp},
@@ -109,9 +100,8 @@ function parser.testentry(entry, test)
 			-- If we find a match, return true
 			if entry:find(v) then return true end
 		end
+		pass = false -- So far, no match. Prob illegal
 	end
-	-- if we didn't return true yet, assume it's not valid
-	pass = false
 	if not entry:find(url_illegal) then
 		if test == "all" or test == "url" then
 			if entry:find(upe) then

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -70,7 +70,6 @@ function parser.test_format(pls)
 	-- Checks all valid chars in file paths. Allows for periods in paths
 	local pass = true
 	local entries = split_entries(pls)
-	local t = {}
 	for index,entry in ipairs(entries) do
 		if parser.test_entry(entry) then pass = true end
 	end

--- a/yeetpls/txt-parser.lua
+++ b/yeetpls/txt-parser.lua
@@ -63,12 +63,20 @@ function parser.test_format(pls)
 	local pass = true
 	local entries = split_entries(pls)
 	local t = {}
+	local fwp = "^%a:[\\/][.-\\/]*.+%.%w+" -- Full Windows path
+	local fnp = "/[.-/]*.+%.%w+" -- full *NIX path
+	local rfp = "[%.+\\/]?[.-\\/]*.+%.%w+" -- relative file path
+	local jaf = ".+%.%w+" -- Just a file
+	local upe = "%a+://[.+%.]?%w+%.%w+[/.]*" -- URL playlist entry
 	for index,entry in ipairs(entries) do
-		if entry:find("[^%z<>:%|%?%*\"]") then -- This filename contains the NULL character. This is universally not allowed
+		if not entry:find("[^%z<>:%|%?%*\"]") then -- This path contains disallowed chars. Win == NIX here, due to effort and media should work everywhere.
 			pass=false
+		elseif not entry:find(fwp) or not entry:find(fnp) or not entry:find(rfp) or not entry:find(jaf) -- check for paths here. If we don't find them...
+			if not entry:find(upe) -- check for URLs. If none:
+				pass=false -- it matches no known inputs
 		end
 	end
-	return pass -- All entries passed the test, playlist is correct.
+	return pass -- All entries passed the test, playlist is correct if this is true.
 end
 
 -- Return the module for use in main.lua


### PR DESCRIPTION
Made some edits to the txt-parser
- Only full path patterns for Windows are different now, the rest was handled with matching both delims
- Exported `split_entries` in the `parser` table because it's a newline splitter which is useful for all parsers
- Cleaned up the newline patterns
- Added a useful comment about pipes
- split off the actual testing of separate entries in `test_format` to `test_entry`
- exported `test_entry` in the `parser` table as a quick & dirty tester for malformed filenames and URIs
- Loads of cleanups to `test_entry` and added defaults.

Made edits to the READMEs
- Added explanation as to why the script-opt is required rather than mpv's `--playlist` option
- Added a table listing what parsers are available, what formats they support and if they're shuffle-safe
- Added explanation on what "shuffle-safe" means
- Added some links
- Officially described READMEs in subdirs
- General cleanup and corrections